### PR TITLE
[FEAT] Feature/#28 individual membership

### DIFF
--- a/src/main/java/com/core/linkup/office/controller/OfficeController.java
+++ b/src/main/java/com/core/linkup/office/controller/OfficeController.java
@@ -2,7 +2,7 @@ package com.core.linkup.office.controller;
 
 
 import com.core.linkup.common.response.BaseResponse;
-import com.core.linkup.office.Service.OfficeService;
+import com.core.linkup.office.service.OfficeService;
 import com.core.linkup.office.request.OfficeSearchRequest;
 import com.core.linkup.office.response.OfficeResponse;
 import com.core.linkup.office.response.OfficeSearchResponse;

--- a/src/main/java/com/core/linkup/office/entity/SeatSpace.java
+++ b/src/main/java/com/core/linkup/office/entity/SeatSpace.java
@@ -1,15 +1,18 @@
 package com.core.linkup.office.entity;
 
 import com.core.linkup.common.entity.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import com.core.linkup.reservation.reservation.entity.Reservation;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity(name = "seat_space")
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class SeatSpace extends BaseEntity {
 
     @ManyToOne
@@ -18,6 +21,9 @@ public class SeatSpace extends BaseEntity {
 
     private String type;
     private String code;
+
+    @OneToMany
+    private List<Reservation> reservations;
 
     public String getLocation() {
         return officeBuilding != null ? officeBuilding.getLocation() : null;

--- a/src/main/java/com/core/linkup/office/entity/enums/SeatSpaceType.java
+++ b/src/main/java/com/core/linkup/office/entity/enums/SeatSpaceType.java
@@ -1,0 +1,15 @@
+package com.core.linkup.office.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SeatSpaceType {
+
+    OPEN_DESK("오픈 데스크"),
+
+    ;
+
+    private String typeName;
+}

--- a/src/main/java/com/core/linkup/office/repository/SeatSpaceRepository.java
+++ b/src/main/java/com/core/linkup/office/repository/SeatSpaceRepository.java
@@ -1,0 +1,14 @@
+package com.core.linkup.office.repository;
+
+import com.core.linkup.common.exception.BaseException;
+import com.core.linkup.common.response.BaseResponseStatus;
+import com.core.linkup.office.entity.SeatSpace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatSpaceRepository extends JpaRepository<SeatSpace, Long> {
+
+    default SeatSpace findFirstById(Long id) {
+        return findById(id).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.DOES_NOT_EXIST));
+    }
+}

--- a/src/main/java/com/core/linkup/office/service/OfficeService.java
+++ b/src/main/java/com/core/linkup/office/service/OfficeService.java
@@ -1,4 +1,4 @@
-package com.core.linkup.office.Service;
+package com.core.linkup.office.service;
 
 import com.core.linkup.common.exception.BaseException;
 import com.core.linkup.office.entity.OfficeBuilding;

--- a/src/main/java/com/core/linkup/reservation/membership/company/repository/CompanyMembershipRepository.java
+++ b/src/main/java/com/core/linkup/reservation/membership/company/repository/CompanyMembershipRepository.java
@@ -5,16 +5,12 @@ import com.core.linkup.common.response.BaseResponseStatus;
 import com.core.linkup.reservation.membership.company.entity.CompanyMembership;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface CompanyMembershipRepository extends JpaRepository<CompanyMembership, Long> {
-
-    Optional<CompanyMembership> findByCompanyId(Long companyId);
 
     Boolean existsByCompanyId(Long companyId);
 
     default CompanyMembership findFirstByCompanyId(Long companyId){
-        return findByCompanyId(companyId).orElseThrow(
+        return findById(companyId).orElseThrow(
                 () -> new BaseException(BaseResponseStatus.DOES_NOT_EXIST)
         );
     }

--- a/src/main/java/com/core/linkup/reservation/membership/individual/converter/IndividualMembershipConverter.java
+++ b/src/main/java/com/core/linkup/reservation/membership/individual/converter/IndividualMembershipConverter.java
@@ -1,0 +1,25 @@
+package com.core.linkup.reservation.membership.individual.converter;
+
+import com.core.linkup.common.annotation.Converter;
+import com.core.linkup.reservation.membership.individual.entity.IndividualMembership;
+import com.core.linkup.reservation.membership.individual.response.IndividualMembershipResponse;
+
+@Converter
+public class IndividualMembershipConverter {
+
+    public IndividualMembershipResponse toIndividualMembershipResponse(
+            IndividualMembership individualMembership) {
+
+        return IndividualMembershipResponse.builder()
+                .id(individualMembership.getId())
+                .location(individualMembership.getLocation())
+                .price(individualMembership.getPrice())
+                .type(individualMembership.getType().getName())
+                .duration(individualMembership.getDuration())
+                .startDate(individualMembership.getStartDate())
+                .endDate(individualMembership.getEndDate())
+                .memberId(individualMembership.getMember().getId())
+                .build();
+
+    }
+}

--- a/src/main/java/com/core/linkup/reservation/membership/individual/entity/IndividualMembership.java
+++ b/src/main/java/com/core/linkup/reservation/membership/individual/entity/IndividualMembership.java
@@ -3,6 +3,7 @@ package com.core.linkup.reservation.membership.individual.entity;
 import com.core.linkup.common.entity.BaseEntity;
 import com.core.linkup.member.entity.Member;
 import com.core.linkup.reservation.membership.individual.entity.enums.MembershipType;
+import com.core.linkup.reservation.reservation.entity.Reservation;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "individual_membership")
@@ -23,15 +25,17 @@ import java.time.LocalDateTime;
 public class IndividualMembership extends BaseEntity {
 
     private String location;
-    private Long price;
     @Enumerated(EnumType.STRING)
     private MembershipType type;
     private Integer duration;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
+    private Long price;
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
     @JsonIgnore
     private Member member;
+
+    @OneToMany(mappedBy = "individualMembership")
+    private List<Reservation> reservations;
 }

--- a/src/main/java/com/core/linkup/reservation/membership/individual/repository/IndividualMembershipRepository.java
+++ b/src/main/java/com/core/linkup/reservation/membership/individual/repository/IndividualMembershipRepository.java
@@ -1,4 +1,7 @@
 package com.core.linkup.reservation.membership.individual.repository;
 
-public interface IndividualMembershipRepository {
+import com.core.linkup.reservation.membership.individual.entity.IndividualMembership;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IndividualMembershipRepository extends JpaRepository<IndividualMembership, Long> {
 }

--- a/src/main/java/com/core/linkup/reservation/membership/individual/request/IndividualMembershipRequest.java
+++ b/src/main/java/com/core/linkup/reservation/membership/individual/request/IndividualMembershipRequest.java
@@ -1,4 +1,16 @@
 package com.core.linkup.reservation.membership.individual.request;
 
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
 public class IndividualMembershipRequest {
+
+    private String location;
+    private String type;
+    private Integer duration;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private Long price;
 }

--- a/src/main/java/com/core/linkup/reservation/membership/individual/service/IndividualMembershipService.java
+++ b/src/main/java/com/core/linkup/reservation/membership/individual/service/IndividualMembershipService.java
@@ -1,7 +1,46 @@
 package com.core.linkup.reservation.membership.individual.service;
 
+import com.core.linkup.member.entity.Member;
+import com.core.linkup.reservation.membership.individual.converter.IndividualMembershipConverter;
+import com.core.linkup.reservation.membership.individual.entity.IndividualMembership;
+import com.core.linkup.reservation.membership.individual.entity.enums.MembershipType;
+import com.core.linkup.reservation.membership.individual.repository.IndividualMembershipRepository;
+import com.core.linkup.reservation.membership.individual.request.IndividualMembershipRequest;
+import com.core.linkup.reservation.membership.individual.response.IndividualMembershipResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class IndividualMembershipService {
+
+    private final IndividualMembershipRepository individualMembershipRepository;
+    private final IndividualMembershipConverter individualMembershipConverter;
+
+    public IndividualMembership buildIndividualMembership(IndividualMembershipRequest request,
+                                                          Member member) {
+        return IndividualMembership.builder()
+                .location(request.getLocation())
+                .type(MembershipType.valueOf(request.getType()))
+                .duration(request.getDuration())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .price(request.getPrice())
+                .member(member)
+                .reservations(new ArrayList<>())
+                .build();
+    }
+
+    public IndividualMembershipResponse toResponse(IndividualMembership individualMembership) {
+        return individualMembershipConverter.toIndividualMembershipResponse(individualMembership);
+    }
+
+    public IndividualMembership saveIndividualMembership(IndividualMembership individualMembership) {
+        return individualMembershipRepository.save(individualMembership);
+    }
+
 }

--- a/src/main/java/com/core/linkup/reservation/reservation/controller/ReservationController.java
+++ b/src/main/java/com/core/linkup/reservation/reservation/controller/ReservationController.java
@@ -1,12 +1,15 @@
 package com.core.linkup.reservation.reservation.controller;
 
 import com.core.linkup.common.response.BaseResponse;
-import com.core.linkup.reservation.membership.company.service.CompanyService;
 import com.core.linkup.reservation.reservation.request.CompanyMembershipRegistrationRequest;
+import com.core.linkup.reservation.reservation.request.IndividualMembershipRegistrationRequest;
 import com.core.linkup.reservation.reservation.response.CompanyMembershipRegistrationResponse;
-import com.core.linkup.reservation.reservation.service.ReservationService;
+import com.core.linkup.reservation.reservation.response.IndividualMembershipRegistrationResponse;
+import com.core.linkup.reservation.reservation.service.TotalReservationService;
+import com.core.linkup.security.MemberDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -15,12 +18,21 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/reservation")
 public class ReservationController {
 
-    private final ReservationService reservationService;
-    private final CompanyService companyService;
+    private final TotalReservationService totalReservationService;
 
     @PostMapping("/company")
-    private BaseResponse<CompanyMembershipRegistrationResponse> registerCompany(@RequestBody CompanyMembershipRegistrationRequest request) {
-        CompanyMembershipRegistrationResponse response = reservationService.registerCompanyMembership(request);
+    public BaseResponse<CompanyMembershipRegistrationResponse> registerCompany(@RequestBody CompanyMembershipRegistrationRequest request) {
+        CompanyMembershipRegistrationResponse response = totalReservationService.registerCompanyMembership(request);
         return BaseResponse.response(response);
     }
+
+    @PostMapping("/{officeId}")
+    public BaseResponse<IndividualMembershipRegistrationResponse> registerIndividual(
+            @RequestBody IndividualMembershipRegistrationRequest request,
+            @PathVariable Long officeId, @AuthenticationPrincipal MemberDetails memberDetails){
+        IndividualMembershipRegistrationResponse response =
+                totalReservationService.registerIndividualMembership(request, memberDetails.getMember());
+        return BaseResponse.response(response);
+    }
+
 }

--- a/src/main/java/com/core/linkup/reservation/reservation/converter/ReservationConverter.java
+++ b/src/main/java/com/core/linkup/reservation/reservation/converter/ReservationConverter.java
@@ -1,0 +1,47 @@
+package com.core.linkup.reservation.reservation.converter;
+
+import com.core.linkup.common.annotation.Converter;
+import com.core.linkup.reservation.membership.company.response.CompanyResponse;
+import com.core.linkup.reservation.membership.individual.response.IndividualMembershipResponse;
+import com.core.linkup.reservation.reservation.entity.Reservation;
+import com.core.linkup.reservation.reservation.response.CompanyMembershipRegistrationResponse;
+import com.core.linkup.reservation.reservation.response.IndividualMembershipRegistrationResponse;
+import com.core.linkup.reservation.reservation.response.ReservationResponse;
+
+import java.util.List;
+
+@Converter
+public class ReservationConverter {
+
+    public CompanyMembershipRegistrationResponse toCompanyRegistrationResponse(
+            CompanyResponse company,
+            com.core.linkup.reservation.membership.company.response.CompanyMembershipResponse companyMembership) {
+
+        return CompanyMembershipRegistrationResponse.builder()
+                .company(company)
+                .companyMembership(companyMembership)
+                .build();
+    }
+
+    public IndividualMembershipRegistrationResponse toIndividualRegistrationResponse(
+            IndividualMembershipResponse membership,
+            List<ReservationResponse> reservations){
+
+        return IndividualMembershipRegistrationResponse.builder()
+                .membership(membership)
+                .reservations(reservations)
+                .build();
+    }
+
+    public ReservationResponse toReservationResponse(
+            Reservation reservation){
+        return ReservationResponse.builder()
+                .type(reservation.getType().getDescription())
+                .startDate(reservation.getStartDate())
+                .endDate(reservation.getEndDate())
+                .price(reservation.getPrice())
+                .seatType(reservation.getSeatSpace().getType())
+                .seatCode(reservation.getSeatSpace().getCode())
+                .build();
+    }
+}

--- a/src/main/java/com/core/linkup/reservation/reservation/entity/Reservation.java
+++ b/src/main/java/com/core/linkup/reservation/reservation/entity/Reservation.java
@@ -1,12 +1,13 @@
 package com.core.linkup.reservation.reservation.entity;
 
 import com.core.linkup.common.entity.BaseEntity;
+import com.core.linkup.member.entity.Member;
+import com.core.linkup.office.entity.SeatSpace;
+import com.core.linkup.reservation.membership.company.entity.CompanyMembership;
+import com.core.linkup.reservation.membership.individual.entity.IndividualMembership;
 import com.core.linkup.reservation.reservation.entity.enums.ReservationStatus;
 import com.core.linkup.reservation.reservation.entity.enums.ReservationType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -24,11 +25,6 @@ import java.time.LocalDateTime;
 @EqualsAndHashCode(callSuper = true)
 public class Reservation extends BaseEntity {
 
-    private Long memberId;
-    private Long indMembershipId;
-    private Long comMembershipId;
-    private Long seatId;
-
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private Long price;
@@ -36,4 +32,13 @@ public class Reservation extends BaseEntity {
     private ReservationStatus status;
     @Enumerated(EnumType.STRING)
     private ReservationType type;
+
+    @ManyToOne
+    private CompanyMembership companyMembership;
+
+    @ManyToOne
+    private IndividualMembership individualMembership;
+
+    @OneToOne
+    private SeatSpace seatSpace;
 }

--- a/src/main/java/com/core/linkup/reservation/reservation/request/IndividualMembershipRegistrationRequest.java
+++ b/src/main/java/com/core/linkup/reservation/reservation/request/IndividualMembershipRegistrationRequest.java
@@ -1,0 +1,14 @@
+package com.core.linkup.reservation.reservation.request;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class IndividualMembershipRegistrationRequest {
+
+    private com.core.linkup.reservation.membership.individual.request.IndividualMembershipRequest membership;
+    private List<ReservationRequest> reservations;
+
+
+}

--- a/src/main/java/com/core/linkup/reservation/reservation/request/ReservationRequest.java
+++ b/src/main/java/com/core/linkup/reservation/reservation/request/ReservationRequest.java
@@ -1,4 +1,16 @@
 package com.core.linkup.reservation.reservation.request;
 
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
 public class ReservationRequest {
+
+    private String type;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private Long price;
+    private Long seatId;
+
 }

--- a/src/main/java/com/core/linkup/reservation/reservation/response/IndividualMembershipRegistrationResponse.java
+++ b/src/main/java/com/core/linkup/reservation/reservation/response/IndividualMembershipRegistrationResponse.java
@@ -1,0 +1,15 @@
+package com.core.linkup.reservation.reservation.response;
+
+import com.core.linkup.reservation.membership.individual.response.IndividualMembershipResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class IndividualMembershipRegistrationResponse {
+
+    private IndividualMembershipResponse membership;
+    private List<ReservationResponse> reservations;
+}

--- a/src/main/java/com/core/linkup/reservation/reservation/response/ReservationResponse.java
+++ b/src/main/java/com/core/linkup/reservation/reservation/response/ReservationResponse.java
@@ -1,4 +1,20 @@
 package com.core.linkup.reservation.reservation.response;
 
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
 public class ReservationResponse {
+
+    private String type;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private Long price;
+
+    private String seatType;
+    private String seatCode;
+
 }

--- a/src/main/java/com/core/linkup/reservation/reservation/service/TotalReservationService.java
+++ b/src/main/java/com/core/linkup/reservation/reservation/service/TotalReservationService.java
@@ -1,0 +1,98 @@
+package com.core.linkup.reservation.reservation.service;
+
+import com.core.linkup.common.exception.BaseException;
+import com.core.linkup.common.response.BaseResponseStatus;
+import com.core.linkup.common.utils.AuthCodeUtils;
+import com.core.linkup.common.utils.EmailUtils;
+import com.core.linkup.common.utils.RedisUtils;
+import com.core.linkup.member.entity.Member;
+import com.core.linkup.reservation.membership.company.entity.Company;
+import com.core.linkup.reservation.membership.company.entity.CompanyMembership;
+import com.core.linkup.reservation.membership.company.service.CompanyMembershipService;
+import com.core.linkup.reservation.membership.company.service.CompanyService;
+import com.core.linkup.reservation.membership.individual.entity.IndividualMembership;
+import com.core.linkup.reservation.membership.individual.service.IndividualMembershipService;
+import com.core.linkup.reservation.reservation.converter.ReservationConverter;
+import com.core.linkup.reservation.reservation.entity.Reservation;
+import com.core.linkup.reservation.reservation.request.CompanyMembershipRegistrationRequest;
+import com.core.linkup.reservation.reservation.request.IndividualMembershipRegistrationRequest;
+import com.core.linkup.reservation.reservation.request.ReservationRequest;
+import com.core.linkup.reservation.reservation.response.CompanyMembershipRegistrationResponse;
+import com.core.linkup.reservation.reservation.response.IndividualMembershipRegistrationResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TotalReservationService {
+
+    private final CompanyService companyService;
+    private final CompanyMembershipService companyMembershipService;
+    private final IndividualMembershipService individualMembershipService;
+    private final ReservationService reservationService;
+    private final AuthCodeUtils authCodeUtils;
+    private final EmailUtils emailUtils;
+    private final RedisUtils redisUtils;
+    private final ReservationConverter reservationConverter;
+
+    @Transactional
+    public CompanyMembershipRegistrationResponse registerCompanyMembership(CompanyMembershipRegistrationRequest request) {
+        Company company = companyService.buildCompany(request.getCompany());
+        CompanyMembership companyMembership =
+                companyMembershipService.saveCompanyMembership(request.getCompanyMembership(), company);
+
+        Company savedCompany = companyService.saveCompany(company, companyMembership);
+
+        String authCode = authCodeUtils.createCompanyAuthCode();
+        sendCompanyAuthCode(company, authCode);
+        redisUtils.saveCompanyAuthCode(authCode, String.valueOf(company.getId())) ;
+
+        return reservationConverter.toCompanyRegistrationResponse(
+                companyService.toResponse(savedCompany),
+                companyMembershipService.toResponse(companyMembership)
+        );
+    }
+
+    public void sendCompanyAuthCode(Company company, String authCode){
+        String subject = "LinkUp 기업 멤버십 인증번호";
+
+        try {
+            emailUtils.sendEmail(company.getManagerEmail(), subject, authCode);
+            redisUtils.saveEmailAuthCode(company.getManagerEmail(), authCode);
+        } catch (Exception e) {
+            log.error("messaging error");
+            throw new BaseException(BaseResponseStatus.EMAIL_ERROR);
+        }
+    }
+
+    public IndividualMembershipRegistrationResponse registerIndividualMembership(
+            IndividualMembershipRegistrationRequest requests,
+            Member member) {
+
+        IndividualMembership membership =
+                individualMembershipService.buildIndividualMembership(requests.getMembership(), member);
+
+        List<Reservation> reservations = new ArrayList<>();
+
+        for (ReservationRequest request : requests.getReservations()){
+            Reservation reservation = reservationService.buildReservation(request, membership);
+            reservations.add(reservationService.saveReservation(reservation));
+            membership.getReservations().add(reservation);
+        }
+
+        individualMembershipService.saveIndividualMembership(membership);
+
+        return reservationConverter.toIndividualRegistrationResponse(
+                individualMembershipService.toResponse(membership),
+                reservations.stream().map(reservationService::toResponse).toList()
+                );
+
+
+    }
+}


### PR DESCRIPTION
## 요약
개인 멤버십 (보류)

## 내용
* 중간배포 후 재개
* 개인 멤버십
  * [x] 연관관계 설정
  * [x] 개인 패스(1일, 30일) 생성
    * [ ] 좌석 예약 (+ 공간 예약)
    * [ ] 검증 로직 (최대 예약 횟수 등)

## 이슈 번호, 링크
#28 