### PR TITLE
[FIX] #56 - 소모임 공지 소유자정보 추가

### DIFF
--- a/src/main/java/com/core/linkup/club/clubnotice/converter/ClubNoticeConverter.java
+++ b/src/main/java/com/core/linkup/club/clubnotice/converter/ClubNoticeConverter.java
@@ -5,6 +5,7 @@ import com.core.linkup.club.clubnotice.response.ClubNoticeResponse;
 import com.core.linkup.club.entity.Club;
 import com.core.linkup.club.entity.ClubNotice;
 import com.core.linkup.common.annotation.Converter;
+import com.core.linkup.common.entity.enums.OccupationType;
 import com.core.linkup.member.entity.Member;
 import com.core.linkup.security.MemberDetails;
 
@@ -31,6 +32,9 @@ public class ClubNoticeConverter {
                 .type(clubNotice.getType())
                 .clubOwnerId(member.getId())
                 .clubOwnerName(member.getName())
+                .clubOwnerThumbnail(member.getProfileImage())
+                .clubOwnerOccupation(member.getOccupation())
+                .date(clubNotice.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/com/core/linkup/club/clubnotice/response/ClubNoticeResponse.java
+++ b/src/main/java/com/core/linkup/club/clubnotice/response/ClubNoticeResponse.java
@@ -1,7 +1,11 @@
 package com.core.linkup.club.clubnotice.response;
 
 import com.core.linkup.club.entity.enums.NotificationType;
+import com.core.linkup.common.entity.enums.OccupationType;
 import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Builder
 public record ClubNoticeResponse(
@@ -10,6 +14,10 @@ public record ClubNoticeResponse(
         String content,
         NotificationType type,
         Long clubOwnerId,
-        String clubOwnerName
+        String clubOwnerName,
+        String clubOwnerThumbnail,
+        OccupationType clubOwnerOccupation,
+        LocalDateTime date
+
 ) {
 }


### PR DESCRIPTION
- 소모임 공지 조회 시, 이미지, 직군, 작성일 나올 수 있도록 하였음