### PR TITLE
[FIX] Fix/#81 available space api

### DIFF
--- a/src/main/java/com/core/linkup/reservation/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/core/linkup/reservation/reservation/repository/ReservationRepositoryCustom.java
@@ -2,6 +2,8 @@ package com.core.linkup.reservation.reservation.repository;
 
 
 import com.core.linkup.office.entity.SeatSpace;
+import com.core.linkup.office.entity.enums.SeatSpaceType;
+import com.core.linkup.reservation.reservation.entity.Reservation;
 import com.querydsl.core.Tuple;
 
 import java.time.LocalDate;
@@ -32,4 +34,8 @@ public interface ReservationRepositoryCustom {
 
     // 잔여 좌석 조회
     List<SeatSpace> findAllSeatSpacesByOfficeIdAndType(Long officeId, String type, LocalDateTime start, LocalDateTime end);
+
+    // 잔여 공간 조회
+    List<Reservation> findAllReservationsBySeatIdAndDateAndType(Long seatId, LocalDateTime startDate, SeatSpaceType type);
+
 }

--- a/src/main/java/com/core/linkup/reservation/reservation/response/SeatSpaceResponse.java
+++ b/src/main/java/com/core/linkup/reservation/reservation/response/SeatSpaceResponse.java
@@ -3,6 +3,8 @@ package com.core.linkup.reservation.reservation.response;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Builder
 @Getter
 public class SeatSpaceResponse {
@@ -10,4 +12,6 @@ public class SeatSpaceResponse {
     private String type;
     private String code;
     private boolean isAvailable;
+    private List<String> am;
+    private List<String> pm;
 }


### PR DESCRIPTION
## 요약
잔여 좌석/공간 조회 api에서 누락된 공간 시간 조회 부분 추가

## 내용
- 기존: 잔여좌석/공간 동일, 예약 좌석/공간 타입 + 날짜 + 시간을 받고 잔여좌석/공간 반환(true, false로 가능 여부)
- 변경: 공간일 경우 날짜와 공간 타입만 보냄, 예약 가능한 시간대 리스트로 반환
  * [x] 날짜와 타입만 받게 수정
  * [x] 응답 형태에 시간대 리스트 포함하도록 수정 (좌석 조회일 때는 null) 
  * [x] 예약 가능한 시간대만 문자열로 리스트에 포함
  * [x] api 호출 시 type에 따른 분기 설정

## 이슈 번호, 링크
#81 