### PR TITLE
[FIX] #84 소모임 게시글 타입 오류

### DIFF
--- a/src/main/java/com/core/linkup/club/clubnotice/entity/ClubNotice.java
+++ b/src/main/java/com/core/linkup/club/clubnotice/entity/ClubNotice.java
@@ -3,6 +3,8 @@ package com.core.linkup.club.clubnotice.entity;
 import com.core.linkup.club.clubnotice.entity.enums.NotificationType;
 import com.core.linkup.common.entity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,5 +21,6 @@ public class ClubNotice extends BaseEntity { // board -> notice
     private Long memberId;
     private String title;
     private String content;
+    @Enumerated(EnumType.STRING)
     private NotificationType type; //게시판 or 공지
 }

--- a/src/main/java/com/core/linkup/club/clubnotice/repository/ClubNoticeCustomRepositoryImpl.java
+++ b/src/main/java/com/core/linkup/club/clubnotice/repository/ClubNoticeCustomRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ClubNoticeCustomRepositoryImpl implements ClubNoticeCustomRepositor
 
         List<ClubNotice> clubNoticeList = queryFactory.selectFrom(clubNotice)
                 .where(clubNotice.clubId.eq(clubId)
-                        .and(clubNotice.type.eq(NotificationType.valueOf("NOTICE"))))
+                        .and(clubNotice.type.eq(NotificationType.NOTICE)))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -54,7 +54,7 @@ public class ClubNoticeCustomRepositoryImpl implements ClubNoticeCustomRepositor
         ClubNotice notice = queryFactory.selectFrom(clubNotice)
                 .where(clubNotice.clubId.eq(clubId)
                         .and(clubNotice.id.eq(noticeId))
-                        .and(clubNotice.type.eq(NotificationType.valueOf("notice"))))
+                        .and(clubNotice.type.eq(NotificationType.NOTICE)))
                 .fetchOne();
 
         if (notice == null) {
@@ -70,14 +70,14 @@ public class ClubNoticeCustomRepositoryImpl implements ClubNoticeCustomRepositor
 
         List<ClubNotice> clubNoticeList = queryFactory.selectFrom(clubNotice)
                 .where(clubNotice.clubId.eq(clubId)
-                        .and(clubNotice.type.eq(NotificationType.valueOf("BOARD"))))
+                        .and(clubNotice.type.eq(NotificationType.BOARD)))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         long total = queryFactory.selectFrom(clubNotice)
                 .where(clubNotice.clubId.eq(clubId)
-                        .and(clubNotice.type.eq(NotificationType.valueOf("BOARD"))))
+                        .and(clubNotice.type.eq(NotificationType.BOARD)))
                 .fetchCount();
 
         return new PageImpl<>(clubNoticeList, pageable, total);
@@ -90,7 +90,7 @@ public class ClubNoticeCustomRepositoryImpl implements ClubNoticeCustomRepositor
         ClubNotice notice = queryFactory.selectFrom(clubNotice)
                 .where(clubNotice.clubId.eq(clubId)
                         .and(clubNotice.id.eq(noticeId))
-                        .and(clubNotice.type.eq(NotificationType.valueOf("BOARD"))))
+                        .and(clubNotice.type.eq(NotificationType.BOARD)))
                 .fetchOne();
 
         return Optional.ofNullable(notice);


### PR DESCRIPTION
## 요약
소모임 게시글/공지사항 개별조회 오류 수정

## 내용
- ClubNotice의 type에 @Enumerated(EnumType.STRING) 누락
- db에 0, 1로 저장되어서 조회 오류
- 누락된 애너테이션 추가, 조회 쿼리 수정

## 이슈 번호, 링크
#84 