### PR TITLE
[REFACTOR] #87 소모임 전체조회 시 좋아요 여부 반영된 api 분리

### DIFF
--- a/src/main/java/com/core/linkup/club/club/controller/ClubController.java
+++ b/src/main/java/com/core/linkup/club/club/controller/ClubController.java
@@ -44,21 +44,23 @@ public class ClubController {
     //TODO : OfficeBuilding으로 조회 가능 하도록 할 예정
     @GetMapping("/search")
     public BaseResponse<Page<ClubSearchResponse>> findClubs(
-            @AuthenticationPrincipal MemberDetails member,
             @PageableDefault(sort = "id", direction = Sort.Direction.ASC) Pageable pageable,
             @ModelAttribute ClubSearchRequest request) {
-
-        if (member!=null) {
-            // 로그인
-            Page<ClubSearchResponse> searchResponse =
-                    clubService.findClubs(member.getMember(), pageable, request);
-            return BaseResponse.response(searchResponse);
-        } else {
             // 비로그인
             Page<ClubSearchResponse> searchResponse =
                     clubService.findClubs(pageable, request);
             return BaseResponse.response(searchResponse);
-        }
+    }
+
+    @GetMapping("/authenticated/search")
+    public BaseResponse<Page<ClubSearchResponse>> findClubsAuthenticated(
+            @AuthenticationPrincipal MemberDetails member,
+            @PageableDefault(sort = "id", direction = Sort.Direction.ASC) Pageable pageable,
+            @ModelAttribute ClubSearchRequest request) {
+        // 로그인
+        Page<ClubSearchResponse> searchResponse =
+                clubService.findClubs(member.getMember(), pageable, request);
+        return BaseResponse.response(searchResponse);
     }
 
     //소모임 등록

--- a/src/main/java/com/core/linkup/club/club/repository/ClubLikeRepository.java
+++ b/src/main/java/com/core/linkup/club/club/repository/ClubLikeRepository.java
@@ -11,5 +11,5 @@ public interface ClubLikeRepository extends JpaRepository<ClubLike, Long> {
 
     void deleteByMemberIdAndClubId(Long memberId, Long clubId);
 
-    List<Long> findClubIdsByMemberId(Long memberId);
+    List<ClubLike> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/core/linkup/club/club/service/ClubService.java
+++ b/src/main/java/com/core/linkup/club/club/service/ClubService.java
@@ -58,6 +58,7 @@ public class ClubService {
         return clubConverter.toClubResponse(club, member, clubMembers, clubMeetings, memberMap);
     }
 
+    // 로그인 시 전체조회
     public Page<ClubSearchResponse> findClubs(Member member, Pageable pageable, ClubSearchRequest request) {
         Page<Club> clubs = clubRepository.findSearchClubs(request, pageable);
         List<Member> members = memberRepository.findAllById(clubs.stream()
@@ -66,13 +67,15 @@ public class ClubService {
         Map<Long, Member> memberMap = members.stream()
                 .collect(Collectors.toMap(Member::getId, Function.identity()));
 
-        List<Long> clubLikes = clubLikeRepository.findClubIdsByMemberId(member.getId());
+        List<ClubLike> clubLikes = clubLikeRepository.findAllByMemberId(member.getId());
+        List<Long> clubLikeIds = clubLikes.stream().map(ClubLike::getClubId).toList();
 
         return clubs.map(club ->
                 clubConverter.toClubResponses(
-                        club, memberMap.get(club.getMemberId()), clubLikes.contains(club.getId())));
+                        club, memberMap.get(club.getMemberId()), clubLikeIds.contains(club.getId())));
     }
 
+    // 비로그인 시 전체조회
     public Page<ClubSearchResponse> findClubs(Pageable pageable, ClubSearchRequest request){
         Page<Club> clubs = clubRepository.findSearchClubs(request, pageable);
         List<Member> members = memberRepository.findAllById(clubs.stream()


### PR DESCRIPTION
## 요약
로그인 했을 때의 소모임 전체조회 api

## 내용
- 로그인한 사용자의 좋아요 여부 반영
- /api/v1/club/authenticated/search 로 분리

## 이슈 번호, 링크
#87 