### PR TITLE
[FIX] 댓글 작성자 이름 표기 수정

### DIFF
--- a/src/main/java/com/core/linkup/club/clubnotice/service/ClubCommentService.java
+++ b/src/main/java/com/core/linkup/club/clubnotice/service/ClubCommentService.java
@@ -11,6 +11,7 @@ import com.core.linkup.club.club.repository.ClubRepository;
 import com.core.linkup.common.exception.BaseException;
 import com.core.linkup.common.response.BaseResponseStatus;
 import com.core.linkup.member.entity.Member;
+import com.core.linkup.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ public class ClubCommentService {
     private final ClubCommentConverter clubCommentConverter;
     private final ClubRepository clubRepository;
     private final ClubNoticeRepository clubNoticeRepository;
+    private final MemberRepository memberRepository;
 
     public ClubCommentResponse createComment(Member member, Long clubId, Long noticeId, ClubCommentRequest request) {
 
@@ -49,7 +51,12 @@ public class ClubCommentService {
         List<ClubComment> comments = clubCommentRepository.findAllByClubNoticeId(noticeId);
 
         return comments.stream()
-                .map(comment -> clubCommentConverter.toClubCommentResponse(comment, member))
+                .map(comment -> {
+                    Member commenter = memberRepository.findById(comment.getClubMemberId()).orElseThrow(
+                            () -> new BaseException(BaseResponseStatus.INVALID_WRITER)
+                    );
+                    return clubCommentConverter.toClubCommentResponse(comment, commenter);
+                })
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/core/linkup/club/clubnotice/service/ClubNoticeService.java
+++ b/src/main/java/com/core/linkup/club/clubnotice/service/ClubNoticeService.java
@@ -111,10 +111,12 @@ public class ClubNoticeService {
     public ClubNoticeResponse findNotice(Member member, Long clubId, Long noticeId) {
         checkClubId(clubId);
         ClubNotice notice = clubNoticeRepository.findNotice(clubId, noticeId);
+        Member writer = memberRepository.findById(notice.getMemberId()).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.INVALID_WRITER));
 
         List<ClubCommentResponse> comments = clubCommentService.findComments(member, clubId, noticeId);
 
-        return clubNoticeConverter.toClubNoticeResponse(notice, comments, member);
+        return clubNoticeConverter.toClubNoticeResponse(notice, comments, writer);
     }
 
     //소모임 수정

--- a/src/main/java/com/core/linkup/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/core/linkup/common/response/BaseResponseStatus.java
@@ -52,7 +52,7 @@ public enum BaseResponseStatus {
     INVALID_COMMENT_ID(false, NOT_FOUND.value(), "댓글이 존재하는지 확인해주세요."),
     INVALID_CLUB_MEMBER(false, NOT_FOUND.value(), "소모임에 등록된 회원이 아닙니다."),
     INVALID_CLUB_MEETING(false, NOT_FOUND.value(), "소모임에 등록된 정기모임이 아닙니다."),
-    INVALID_WRITER(false, NOT_FOUND.value(), "작성자가 아닙니다."),
+    INVALID_WRITER(false, NOT_FOUND.value(), "작성자 오류가 발생했습니다."),
     INVALID_MEMBERSHIP(false, NOT_FOUND.value(),"멤버십을 먼저 구매 후에 이용해 주세요"),
     DUPLICATE_CLUB_LIKE(false, BAD_REQUEST.value(), "이미 좋아요를 눌렀습니다"),
     OWNER_CANNOT_JOIN_CLUB(false, NOT_FOUND.value(), "소모임 소유자는 가입할 수 없습니다"),


### PR DESCRIPTION
## 요약
댓글 작성자 이름 표기 오류 수정

## 내용
- 인증된 사용자의 이름이 표기되던 오류
- 작성자 불러오도록 수정

## 이슈 번호, 내용
x