### PR TITLE
[FIX] #138 - 댓글 정렬 수정 및 조회 수정

### DIFF
--- a/src/main/java/com/core/linkup/club/clubnotice/converter/ClubCommentConverter.java
+++ b/src/main/java/com/core/linkup/club/clubnotice/converter/ClubCommentConverter.java
@@ -1,5 +1,6 @@
 package com.core.linkup.club.clubnotice.converter;
 
+import com.core.linkup.club.club.entity.ClubMember;
 import com.core.linkup.club.clubnotice.request.ClubCommentRequest;
 import com.core.linkup.club.clubnotice.response.ClubCommentResponse;
 import com.core.linkup.club.clubnotice.entity.ClubComment;
@@ -17,13 +18,12 @@ public class ClubCommentConverter {
                 .build();
     }
 
-    public ClubCommentResponse toClubCommentResponse(ClubComment clubComment, Member member) {
+    public ClubCommentResponse toClubCommentResponse(ClubComment clubComment, ClubMember writer, Member member) {
         return ClubCommentResponse.builder()
                 .commentId(clubComment.getId())
                 .clubNoticeId(clubComment.getClubNoticeId())
-                .clubNoticeId(clubComment.getClubNoticeId())
                 .comment(clubComment.getComment())
-                .clubMemberId(member.getId())
+                .clubMemberId(writer.getId())
                 .clubMemberUsername(member.getUsername())
                 .clubMemberThumbnail(member.getProfileImage())
                 .clubMemberOccupation(member.getOccupation())

--- a/src/main/java/com/core/linkup/club/clubnotice/repository/ClubCommentCustomRepositoryImpl.java
+++ b/src/main/java/com/core/linkup/club/clubnotice/repository/ClubCommentCustomRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.core.linkup.club.clubnotice.repository;
 
 import com.core.linkup.club.club.entity.QClubMember;
+import com.core.linkup.club.clubnotice.entity.ClubComment;
 import com.core.linkup.club.clubnotice.entity.QClubComment;
+import com.core.linkup.club.clubnotice.entity.QClubNotice;
 import com.core.linkup.member.entity.QMember;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -16,17 +18,29 @@ public class ClubCommentCustomRepositoryImpl implements ClubCommentCustomReposit
 
     @Override
     public List<Tuple> findAllCommentsAndWriters(Long noticeId) {
+        QClubNotice qClubNotice = QClubNotice.clubNotice;
         QClubComment qClubComment = QClubComment.clubComment;
         QClubMember qClubMember = QClubMember.clubMember;
         QMember qMember = QMember.member;
 
-        return queryFactory.select(qClubComment, qMember)
+        return queryFactory.select(qClubComment, qClubMember, qMember)
                 .from(qClubComment)
+//                .join(qClubNotice).on(qClubNotice.id.eq(noticeId))
                 .join(qClubMember).on(qClubComment.clubMemberId.eq(qClubMember.id))
-                .join(qMember).on(qMember.id.eq(qClubMember.memberId))
-                .orderBy(qClubComment.createdAt.desc())
+                .join(qMember).on(qClubMember.memberId.eq(qMember.id))
+                .where(qClubComment.clubNoticeId.eq(noticeId)
+//                        .and(qMember.id.eq(qClubMember.memberId))
+                        )
+                .orderBy(qClubComment.createdAt.asc())
                 .fetch();
     }
 
+    //    return queryFactory.select(qClubComment, qClubMember, qMember)
+    //            .from(qClubComment)
+    //            .join(qClubMember).on(qClubComment.clubMemberId.eq(qClubMember.id))
+    //            .join(qMember).on(qClubMember.memberId.eq(qMember.id))
+    //            .where(qClubComment.clubNoticeId.eq(noticeId))
+    //            .orderBy(qClubComment.createdAt.asc())
+    //            .fetch();
 
 }


### PR DESCRIPTION
- 댓글 정렬 최신순이 나중에 오도록 수정
- 동일한 댓글 내용 출력되는 에러 수정